### PR TITLE
Run OpenSSF scorecard workflow and show badge

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,53 @@
+# Scorecards' GitHub action
+
+name: Scorecard supply-chain security
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  schedule:
+    - cron: '12 10 * * 1'
+  push:
+    branches: [ "main" ]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@dc50aa9510b46c811795eb24b2f1ba02a914e534 # v2.3.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@b611370bb5703a7efb587f9d136a52ea24c5c38c # v3.25.11
+        with:
+          sarif_file: results.sarif

--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,9 @@ oneAPI Specification Web Site
 .. image:: https://github.com/uxlfoundation/oneapi-spec-site/actions/workflows/publish.yaml/badge.svg
    :target: https://github.com/uxlfoundation/oneapi-spec-site/actions/workflows/publish.yaml
 
+.. image:: https://api.scorecard.dev/projects/github.com/uxlfoundation/oneapi-spec-site/badge
+   :target: https://scorecard.dev/viewer/?uri=github.com/uxlfoundation/oneapi-spec-site
+
 This repository contains the source files for the oneAPI Specification web
 site.
 


### PR DESCRIPTION
> [Scorecard](https://scorecard.dev/#learn-more) assesses open source projects for security risks through a series of automated checks.

The following changes will run the OpenSSF scorecard security scan on `main` branch changes, and periodically on a weekly basis. It will create a report of the project status with recommendations. We also add the scorecard badge to the README file. 