### PR TITLE
Enable dependabot dependency updates and pin dependencies by version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  # Enable version updates for Python Pip
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      python-packages:
+        patterns:
+          - "*"
+  # Enable version updates for Github Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -11,8 +11,8 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+    - uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
     - name: Install Dependencies
       run: pip install -r requirements.txt
-    - uses: pre-commit/action@v3.0.1
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+    - uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
       with:
         python-version: '3.11'
     - name: Install Dependencies

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,7 +39,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
         with:
           name: SARIF file
           path: results.sarif
@@ -48,6 +48,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@b611370bb5703a7efb587f9d136a52ea24c5c38c # v3.25.11
+        uses: github/codeql-action/upload-sarif@4fa2a7953630fd2f3fb380f21be14ede0169dd4f # v3.25.12
         with:
           sarif_file: results.sarif

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-click
-pre-commit
-PyYAML
-Sphinx
-sphinx-book-theme
-sphinx-notfound-page
-sphinxcontrib-spelling
+click==8.1.7
+pre-commit==3.7.1
+PyYAML==6.0.1
+Sphinx==7.4.5
+sphinx-book-theme==1.1.3
+sphinx-notfound-page==1.0.2
+sphinxcontrib-spelling==8.0.0


### PR DESCRIPTION
Dependabot is a dependency management and monitoring tool that allows us to avoid supply chain vulnerabilities. Combined with pinned dependencies on our package management systems or GitHub actions, it allows us to keep track of the changes and automatically opens the required pull requests.

Enabling Dependendabot requires repository maintainer permissiones. These are the settings we would recommend: on Settings > Code security and analysis:
* Enable **Dependabot alerts**
* Enable **Dependabot security updates**
* Enable **Dependabot version updates**
* Enable **Dependabot on Actions runners**

In the following changes we are pinning versions for the GitHub actions and Python Pip `requirements.txt` file. Dependabot will run weekly, opening a PR suggesting newer versions of each dependency if available. 

Another advantage of using this strategy is we will find out if the workflow fails with newer dependency versions in the PR, instead of finding out when we trigger the `publish` workflow manually. 

Also, this should rise the project OSSF score. 